### PR TITLE
Add Prettier formatting setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next"
+  "extends": ["next", "prettier"]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "next": "14.1.0",
@@ -21,6 +22,8 @@
     "@types/react": "^18.0.0",
     "@types/node": "^20.0.0",
     "eslint": "^8.0.0",
-    "eslint-config-next": "14.1.0"
+    "eslint-config-next": "14.1.0",
+    "prettier": "^3.0.0",
+    "eslint-config-prettier": "^9.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a Prettier configuration
- extend ESLint with `prettier`
- expose a `format` script in `package.json`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa9dd7388321aa48e05fbcdd72c3