### PR TITLE
Add bento grid layout with links

### DIFF
--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+export default function Blog() {
+  return (
+    <>
+      <Head>
+        <title>Blog</title>
+      </Head>
+      <main className="min-h-screen p-8 bg-gray-100">
+        <h1 className="text-3xl font-bold mb-4">Blog</h1>
+        <p>Posts coming soon.</p>
+      </main>
+    </>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,6 @@
-import Head from 'next/head'
+import Head from 'next/head';
+import Image from 'next/image';
+import Link from 'next/link';
 
 export default function Home() {
   return (
@@ -7,31 +9,97 @@ export default function Home() {
         <title>Personal Website</title>
         <meta name="description" content="Portfolio" />
       </Head>
-      <main className="min-h-screen p-8 bg-gray-100">
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 auto-rows-[minmax(100px,1fr)]">
-          <section className="bg-white p-4 rounded shadow col-span-2 row-span-2">
-            <h2 className="text-xl font-bold mb-2">About</h2>
-            <p>This is a short blurb about me.</p>
+      <main className="min-h-screen bg-gray-100 flex items-center justify-center p-6">
+        <div className="grid w-full max-w-5xl gap-6 sm:grid-cols-2 lg:grid-cols-3 auto-rows-[200px]">
+          <section className="relative col-span-2 row-span-2 rounded-3xl bg-white p-6 shadow-lg hover:scale-105 transition-transform">
+            <h2 className="mb-2 text-xl font-bold flex items-center gap-2">
+              <span className="animate-bounce">👋</span>About
+            </h2>
+            <p className="text-gray-700">This is a short blurb about me.</p>
           </section>
-          <section className="bg-white p-4 rounded shadow">
-            <h2 className="font-semibold">Portfolio Item 1</h2>
-          </section>
-          <section className="bg-white p-4 rounded shadow">
-            <h2 className="font-semibold">Portfolio Item 2</h2>
-          </section>
-          <section className="bg-white p-4 rounded shadow">
-            <h2 className="font-semibold">Portfolio Item 3</h2>
-          </section>
-          <section className="bg-white p-4 rounded shadow col-span-2">
-            <h2 className="text-xl font-bold mb-2">Contact</h2>
-            <ul className="space-x-4 flex">
-              <li><a href="#" className="text-blue-600">Email</a></li>
-              <li><a href="#" className="text-blue-600">LinkedIn</a></li>
-              <li><a href="#" className="text-blue-600">GitHub</a></li>
+
+          <Link
+            href="/projects"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?laptop"
+              alt="Projects"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+              <h2 className="text-xl font-semibold text-white">Projects</h2>
+            </div>
+          </Link>
+
+          <Link
+            href="/blog"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?writing"
+              alt="Blog"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+              <h2 className="text-xl font-semibold text-white">Blog</h2>
+            </div>
+          </Link>
+
+          <Link
+            href="/skills"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?idea"
+              alt="Skill Sprint"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+              <h2 className="text-xl font-semibold text-white">Skill Sprint</h2>
+            </div>
+          </Link>
+
+          <Link
+            href="/moral"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?book"
+              alt="Moral Constitution"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+              <h2 className="text-xl font-semibold text-white">Moral Code</h2>
+            </div>
+          </Link>
+
+          <section className="col-span-2 rounded-3xl bg-white p-6 shadow-lg hover:scale-105 transition-transform">
+            <h2 className="mb-2 text-xl font-bold">Contact</h2>
+            <ul className="flex space-x-4">
+              <li>
+                <a href="#" className="text-blue-600 hover:underline">
+                  Email
+                </a>
+              </li>
+              <li>
+                <a href="#" className="text-blue-600 hover:underline">
+                  LinkedIn
+                </a>
+              </li>
+              <li>
+                <a href="#" className="text-blue-600 hover:underline">
+                  GitHub
+                </a>
+              </li>
             </ul>
           </section>
         </div>
       </main>
     </>
-  )
+  );
 }

--- a/pages/moral.tsx
+++ b/pages/moral.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+export default function Moral() {
+  return (
+    <>
+      <Head>
+        <title>Moral Constitution</title>
+      </Head>
+      <main className="min-h-screen p-8 bg-gray-100">
+        <h1 className="text-3xl font-bold mb-4">Moral Constitution</h1>
+        <p>This page will link to my philosophy and ethics repo.</p>
+      </main>
+    </>
+  );
+}

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+export default function Projects() {
+  return (
+    <>
+      <Head>
+        <title>Projects</title>
+      </Head>
+      <main className="min-h-screen p-8 bg-gray-100">
+        <h1 className="text-3xl font-bold mb-4">Projects</h1>
+        <p>Project showcase coming soon.</p>
+      </main>
+    </>
+  );
+}

--- a/pages/skills.tsx
+++ b/pages/skills.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+export default function Skills() {
+  return (
+    <>
+      <Head>
+        <title>Skill Sprint</title>
+      </Head>
+      <main className="min-h-screen p-8 bg-gray-100">
+        <h1 className="text-3xl font-bold mb-4">Skill Sprint</h1>
+        <p>Examples of fast learning will appear here.</p>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add animated bento grid on home page linking to new sections
- create placeholder pages for Blog, Projects, Skill Sprint, and Moral Constitution

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f0575e948321889272c47b12d52d