### PR TITLE
Allow Unsplash images in Next.js config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'source.unsplash.com',
+      },
+    ],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add `images.remotePatterns` config so Next.js can load Unsplash images

## Testing
- `npm install` *(fails: 403 Forbidden – registry.npmjs.org)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686408724af88321aa65b9b90556ec3c