### PR TITLE
Add header layout with navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ npm run dev
 
 Then open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](./LICENSE) for details.

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  return (
+    <div className="min-h-screen flex flex-col bg-black text-gray-100">
+      <header className="flex items-center justify-between px-6 py-4 bg-black/80 sticky top-0 z-10">
+        <div className="text-2xl font-bold text-gold">Rohan</div>
+        <nav className="space-x-4 text-lg font-medium">
+          <Link href="/" className="hover:text-gold transition-colors">
+            Home
+          </Link>
+          <Link href="/projects" className="hover:text-gold transition-colors">
+            Projects
+          </Link>
+          <Link href="/blog" className="hover:text-gold transition-colors">
+            Blog
+          </Link>
+          <Link href="/about" className="hover:text-gold transition-colors">
+            About
+          </Link>
+          <Link href="/cv" className="hover:text-gold transition-colors">
+            CV
+          </Link>
+        </nav>
+        <div className="flex space-x-4 text-gold">
+          <a
+            href="https://github.com"
+            aria-label="GitHub"
+            className="hover:text-white"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              className="w-6 h-6"
+            >
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.799 8.207 11.387.6.111.793-.261.793-.577 0-.285-.01-1.04-.016-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.334-1.756-1.334-1.756-1.091-.746.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.072 1.835 2.809 1.305 3.495.998.108-.776.42-1.305.763-1.604-2.665-.304-5.466-1.332-5.466-5.931 0-1.31.469-2.381 1.236-3.221-.124-.303-.536-1.521.117-3.176 0 0 1.008-.322 3.301 1.23a11.52 11.52 0 013.005-.404c1.02.005 2.047.138 3.004.404 2.291-1.552 3.297-1.23 3.297-1.23.655 1.655.243 2.873.119 3.176.77.84 1.235 1.911 1.235 3.221 0 4.61-2.804 5.624-5.476 5.921.43.371.814 1.102.814 2.222 0 1.604-.015 2.896-.015 3.287 0 .319.192.694.801.576C20.565 21.796 24 17.297 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+          </a>
+          <a
+            href="https://linkedin.com"
+            aria-label="LinkedIn"
+            className="hover:text-white"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              className="w-6 h-6"
+            >
+              <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.761 0 5-2.239 5-5v-14c0-2.761-2.239-5-5-5zm-11 19h-3v-10h3v10zm-1.5-11.268c-.966 0-1.75-.784-1.75-1.75s.784-1.75 1.75-1.75 1.75.784 1.75 1.75-.783 1.75-1.75 1.75zm13.5 11.268h-3v-5.604c0-1.337-.026-3.066-1.868-3.066-1.868 0-2.154 1.46-2.154 2.97v5.7h-3v-10h2.881v1.367h.041c.401-.759 1.381-1.559 2.841-1.559 3.041 0 3.604 2.002 3.604 4.605v5.587z" />
+            </svg>
+          </a>
+          <a
+            href="mailto:email@example.com"
+            aria-label="Email"
+            className="hover:text-white"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              className="w-6 h-6"
+            >
+              <path d="M12 12.713l-11.985-7.213v13.5c0 1.104.896 2 2 2h19.971c1.104 0 2-.896 2-2v-13.5l-11.986 7.213zm11.986-9.713c0-1.104-.896-2-2-2h-19.971c-1.104 0-2 .896-2 2v.217l11.986 7.213 11.985-7.213v-.217z" />
+            </svg>
+          </a>
+        </div>
+      </header>
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
-import type { AppProps } from 'next/app'
-import '../styles/globals.css'
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return <Component {...pageProps} />;
 }

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import Layout from '../components/Layout';
+
+export default function About() {
+  return (
+    <Layout>
+      <Head>
+        <title>About</title>
+      </Head>
+      <div className="min-h-screen p-8 bg-gray-900 text-gray-100">
+        <h1 className="text-3xl font-bold mb-4 text-gold">About</h1>
+        <p>A short biography will appear here.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import Layout from '../components/Layout';
+
+export default function Blog() {
+  return (
+    <Layout>
+      <Head>
+        <title>Blog</title>
+      </Head>
+      <div className="min-h-screen p-8 bg-gray-900 text-gray-100">
+        <h1 className="text-3xl font-bold mb-4 text-gold">Blog</h1>
+        <p>Posts coming soon.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/cv.tsx
+++ b/pages/cv.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import Layout from '../components/Layout';
+
+export default function CV() {
+  return (
+    <Layout>
+      <Head>
+        <title>CV</title>
+      </Head>
+      <div className="min-h-screen p-8 bg-gray-900 text-gray-100">
+        <h1 className="text-3xl font-bold mb-4 text-gold">CV</h1>
+        <p>My resume will be available here.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,37 +1,106 @@
-import Head from 'next/head'
+import Head from 'next/head';
+import Image from 'next/image';
+import Link from 'next/link';
+import Layout from '../components/Layout';
 
 export default function Home() {
   return (
-    <>
+    <Layout>
       <Head>
         <title>Personal Website</title>
         <meta name="description" content="Portfolio" />
       </Head>
-      <main className="min-h-screen p-8 bg-gray-100">
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 auto-rows-[minmax(100px,1fr)]">
-          <section className="bg-white p-4 rounded shadow col-span-2 row-span-2">
-            <h2 className="text-xl font-bold mb-2">About</h2>
-            <p>This is a short blurb about me.</p>
+      <main className="flex items-center justify-center">
+        <div className="grid w-full max-w-5xl gap-6 p-6 mx-auto sm:grid-cols-2 lg:grid-cols-3 auto-rows-[200px] bg-gray-900">
+          <section className="relative col-span-2 row-span-2 rounded-3xl bg-gray-800 p-6 shadow-lg hover:scale-105 transition-transform">
+            <h2 className="mb-2 text-xl font-bold flex items-center gap-2">
+              <span className="animate-bounce">👋</span>About
+            </h2>
+            <p className="text-gray-300">This is a short blurb about me.</p>
           </section>
-          <section className="bg-white p-4 rounded shadow">
-            <h2 className="font-semibold">Portfolio Item 1</h2>
-          </section>
-          <section className="bg-white p-4 rounded shadow">
-            <h2 className="font-semibold">Portfolio Item 2</h2>
-          </section>
-          <section className="bg-white p-4 rounded shadow">
-            <h2 className="font-semibold">Portfolio Item 3</h2>
-          </section>
-          <section className="bg-white p-4 rounded shadow col-span-2">
-            <h2 className="text-xl font-bold mb-2">Contact</h2>
-            <ul className="space-x-4 flex">
-              <li><a href="#" className="text-blue-600">Email</a></li>
-              <li><a href="#" className="text-blue-600">LinkedIn</a></li>
-              <li><a href="#" className="text-blue-600">GitHub</a></li>
+
+          <Link
+            href="/projects"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?laptop"
+              alt="Projects"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+              <h2 className="text-xl font-semibold text-white">Projects</h2>
+            </div>
+          </Link>
+
+          <Link
+            href="/blog"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?writing"
+              alt="Blog"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+              <h2 className="text-xl font-semibold text-white">Blog</h2>
+            </div>
+          </Link>
+
+          <Link
+            href="/skills"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?idea"
+              alt="Skill Sprint"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+              <h2 className="text-xl font-semibold text-white">Skill Sprint</h2>
+            </div>
+          </Link>
+
+          <Link
+            href="/moral"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?book"
+              alt="Moral Constitution"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+              <h2 className="text-xl font-semibold text-white">Moral Code</h2>
+            </div>
+          </Link>
+
+          <section className="col-span-2 rounded-3xl bg-gray-800 p-6 shadow-lg hover:scale-105 transition-transform">
+            <h2 className="mb-2 text-xl font-bold text-gold">Contact</h2>
+            <ul className="flex space-x-4 text-emerald">
+              <li>
+                <a href="#" className="hover:text-gold">
+                  Email
+                </a>
+              </li>
+              <li>
+                <a href="#" className="hover:text-gold">
+                  LinkedIn
+                </a>
+              </li>
+              <li>
+                <a href="#" className="hover:text-gold">
+                  GitHub
+                </a>
+              </li>
             </ul>
           </section>
         </div>
       </main>
-    </>
-  )
+    </Layout>
+  );
 }

--- a/pages/moral.tsx
+++ b/pages/moral.tsx
@@ -1,0 +1,18 @@
+import Head from 'next/head';
+import Layout from '../components/Layout';
+
+export default function Moral() {
+  return (
+    <Layout>
+      <Head>
+        <title>Moral Constitution</title>
+      </Head>
+      <div className="min-h-screen p-8 bg-gray-900 text-gray-100">
+        <h1 className="text-3xl font-bold mb-4 text-gold">
+          Moral Constitution
+        </h1>
+        <p>This page will link to my philosophy and ethics repo.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import Layout from '../components/Layout';
+
+export default function Projects() {
+  return (
+    <Layout>
+      <Head>
+        <title>Projects</title>
+      </Head>
+      <div className="min-h-screen p-8 bg-gray-900 text-gray-100">
+        <h1 className="text-3xl font-bold mb-4 text-gold">Projects</h1>
+        <p>Project showcase coming soon.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/skills.tsx
+++ b/pages/skills.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import Layout from '../components/Layout';
+
+export default function Skills() {
+  return (
+    <Layout>
+      <Head>
+        <title>Skill Sprint</title>
+      </Head>
+      <div className="min-h-screen p-8 bg-gray-900 text-gray-100">
+        <h1 className="text-3xl font-bold mb-4 text-gold">Skill Sprint</h1>
+        <p>Examples of fast learning will appear here.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,4 +3,4 @@ module.exports = {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,9 +2,15 @@
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        gold: '#d4af37',
+        emerald: '#2ecc71',
+      },
+    },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- create a shared header component with nav links and icons
- apply dark theme colors
- update all pages to use the new layout
- add placeholder About and CV pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6863f0575e948321889272c47b12d52d