### PR TITLE
Fix unsplash image loader

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-
-
- };
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'source.unsplash.com',
+        pathname: '/**',
+      },
+    ],
+  },
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow unsplash images in `next/image`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686433b449648321a283c3795b84663b