### PR TITLE
Improve colors and layout

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -9,7 +9,7 @@ interface LayoutProps {
 export default function Layout({ children }: LayoutProps) {
   return (
     <div className="min-h-screen flex flex-col bg-cream text-dark-green">
-      <header className="flex items-center justify-between px-6 py-4 bg-pastel-green sticky top-0 z-10">
+      <header className="sticky top-4 z-10 mx-4 rounded-full bg-pastel-green px-6 py-4 shadow-lg flex items-center justify-between">
         <div className="text-2xl font-bold">Rohan</div>
         <nav className="space-x-4 text-lg font-medium">
           <Link href="/" className="hover:opacity-80 transition-colors">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,8 +14,8 @@ export default function Home() {
       </Head>
 
       <main className="flex items-center justify-center">
-        <div className="grid w-full max-w-5xl gap-6 p-6 mx-auto sm:grid-cols-2 lg:grid-cols-3 auto-rows-[200px] bg-cream">
-          <section className="relative col-span-2 row-span-2 rounded-3xl bg-pastel-green p-6 shadow-lg hover:scale-105 transition-transform">
+        <div className="grid w-full max-w-5xl mx-auto gap-6 p-6 sm:grid-cols-2 lg:grid-cols-3 auto-rows-fr bg-cream min-h-screen">
+          <section className="relative col-span-2 row-span-2 rounded-3xl bg-pastel-blue p-6 shadow-lg hover:scale-105 transition-transform">
             <h2 className="mb-2 text-xl font-bold flex items-center gap-2">
               <span className="animate-bounce">👋</span>About
             </h2>
@@ -90,6 +90,35 @@ export default function Home() {
             </div>
           </Link>
 
+          <Link
+            href="/about"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?person"
+              alt="About"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <h2 className="text-xl font-semibold text-white">About</h2>
+            </div>
+          </Link>
+
+          <Link
+            href="/cv"
+            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
+          >
+            <Image
+              src="https://source.unsplash.com/random/800x600?resume"
+              alt="CV"
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <h2 className="text-xl font-semibold text-white">CV</h2>
+            </div>
+          </Link>
 
           <section className="col-span-2 rounded-3xl bg-pastel-green p-6 shadow-lg hover:scale-105 transition-transform">
             <h2 className="mb-2 text-xl font-bold">Contact</h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,11 +7,11 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        gold: '#d4af37',
-        emerald: '#2ecc71',
         cream: '#fdfbea',
         'pastel-green': '#b7e4c7',
-        'dark-green': '#355e3b',
+        'pastel-blue': '#a7d8de',
+        'pastel-yellow': '#fff3b0',
+        'dark-green': '#386641',
       },
     },
   },


### PR DESCRIPTION
## Summary
- adjust pastel palette in Tailwind config
- round and elevate the header for a bubble look
- expand bento layout, fill screen vertically
- add About and CV modules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68643af498d48321b14ed5920b0ef08e