### PR TITLE
Refine color themes and nav animation

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,31 +4,68 @@ import Link from 'next/link';
 
 interface LayoutProps {
   children: ReactNode;
+  activeSection?: string;
+  onSectionChange?: (section: string) => void;
+  backgroundClass?: string;
+  headerBgClass?: string;
+  accentColorClass?: string;
 }
 
-export default function Layout({ children }: LayoutProps) {
+export default function Layout({
+  children,
+  activeSection = '',
+  onSectionChange,
+  backgroundClass = 'bg-cream',
+  headerBgClass = 'bg-sage-200',
+  accentColorClass = 'text-dark-green',
+}: LayoutProps) {
+  const sections = ['Home', 'Projects', 'Blog', 'About', 'CV'];
+
   return (
-    <div className="min-h-screen flex flex-col bg-cream text-dark-green">
-      <header className="sticky top-4 z-10 mx-4 rounded-full bg-pastel-green px-6 py-4 shadow-lg flex items-center justify-between">
-        <div className="text-2xl font-bold">Rohan</div>
-        <nav className="space-x-4 text-lg font-medium">
-          <Link href="/" className="hover:opacity-80 transition-colors">
-            Home
-          </Link>
-          <Link href="/projects" className="hover:opacity-80 transition-colors">
-            Projects
-          </Link>
-          <Link href="/blog" className="hover:opacity-80 transition-colors">
-            Blog
-          </Link>
-          <Link href="/about" className="hover:opacity-80 transition-colors">
-            About
-          </Link>
-          <Link href="/cv" className="hover:opacity-80 transition-colors">
-            CV
-          </Link>
-        </nav>
-        <div className="flex space-x-4">
+    <div className={`min-h-screen flex flex-col ${backgroundClass} transition-colors`}>
+      <header className={`sticky top-4 z-10 mx-4 rounded-full px-4 py-3 shadow-lg flex items-center justify-between ${headerBgClass}`}>
+        <div className={`text-2xl font-bold ${accentColorClass}`}>Rohan</div>
+        {onSectionChange ? (
+          <nav className="relative flex flex-1 items-center text-sm font-medium justify-center">
+            <div className="relative flex flex-1 max-w-md bg-gray-100 rounded-full p-1">
+              {sections.map((sec) => (
+                <button
+                  key={sec}
+                  onClick={() => onSectionChange(sec)}
+                  className={`flex-1 px-3 py-1 text-center rounded-full transition-colors ${activeSection === sec ? accentColorClass : accentColorClass + '/60'}`}
+                >
+                  {sec}
+                </button>
+              ))}
+              <span
+                className={`absolute top-1 left-1 h-[calc(100%-0.5rem)] w-[20%] rounded-full shadow transition-transform duration-500 bg-current/30 ${accentColorClass}`}
+                style={{
+                  transform: `translateX(${sections.indexOf(activeSection) * 100}%)`,
+                  transitionTimingFunction: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+                } as React.CSSProperties}
+              />
+            </div>
+          </nav>
+        ) : (
+          <nav className="space-x-4 text-lg font-medium">
+            <Link href="/" className="hover:opacity-80 transition-colors">
+              Home
+            </Link>
+            <Link href="/projects" className="hover:opacity-80 transition-colors">
+              Projects
+            </Link>
+            <Link href="/blog" className="hover:opacity-80 transition-colors">
+              Blog
+            </Link>
+            <Link href="/about" className="hover:opacity-80 transition-colors">
+              About
+            </Link>
+            <Link href="/cv" className="hover:opacity-80 transition-colors">
+              CV
+            </Link>
+          </nav>
+        )}
+        <div className={`flex space-x-4 ${accentColorClass}`}>
           <a
             href="https://github.com"
             aria-label="GitHub"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,156 +1,208 @@
-
-import React from 'react';
+import React, { useState } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
-import Link from 'next/link';
 import Layout from '../components/Layout';
 
+const sections = ['Home', 'Projects', 'Blog', 'About', 'CV'];
+
 export default function Home() {
+  const [activeSection, setActiveSection] = useState('Home');
+
+  const themeMap: Record<string, { bg: string; header: string; accent: string }> = {
+    Home: { bg: 'bg-cream', header: 'bg-gray-100', accent: 'text-black' },
+    Projects: { bg: 'bg-blue-50', header: 'bg-blue-200', accent: 'text-blue-600' },
+    Blog: { bg: 'bg-orange-50', header: 'bg-orange-200', accent: 'text-orange-500' },
+    About: { bg: 'bg-purple-50', header: 'bg-purple-200', accent: 'text-purple-500' },
+    CV: { bg: 'bg-sage-100', header: 'bg-sage-300', accent: 'text-sage-700' },
+  };
+
   return (
-    <Layout>
+    <Layout
+      activeSection={activeSection}
+      onSectionChange={setActiveSection}
+      backgroundClass={themeMap[activeSection].bg}
+      headerBgClass={themeMap[activeSection].header}
+      accentColorClass={themeMap[activeSection].accent}
+    >
       <Head>
         <title>Personal Website</title>
         <meta name="description" content="Portfolio" />
       </Head>
 
-      <main className="flex items-center justify-center">
-
-        <div className="grid w-full max-w-screen-xl mx-auto gap-6 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-fr bg-cream min-h-screen">
-
-          <section className="relative col-span-2 row-span-2 rounded-3xl bg-pastel-blue p-6 shadow-lg hover:scale-105 transition-transform">
-            <h2 className="mb-2 text-xl font-bold flex items-center gap-2">
-              <span className="animate-bounce">👋</span>About
-            </h2>
-            <p>This is a short blurb about me.</p>
-
-          </section>
-
-          <Link
-            href="/projects"
-            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
-          >
-            <Image
-              src="https://source.unsplash.com/random/800x600?laptop"
-              alt="Projects"
-              fill
-              className="object-cover"
-            />
-
-            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
-
-              <h2 className="text-xl font-semibold text-white">Projects</h2>
+      <main className="flex items-center justify-center pt-12">
+        {activeSection === 'Home' && (
+          <div className="mt-8 grid w-full max-w-5xl mx-auto gap-8 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px] min-h-[80vh]">
+            <section className="relative col-span-2 row-span-2 rounded-3xl bg-gray-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold flex items-center gap-2">
+                <span className="animate-bounce">👋</span>About
+              </h2>
+              <p>This is a short blurb about me.</p>
+            </section>
+            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform">
+              <Image src="https://source.unsplash.com/random/800x600?laptop" alt="Projects" fill className="object-cover" />
+              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+                <h2 className="text-xl font-semibold text-white">Projects</h2>
+              </div>
             </div>
-          </Link>
-
-          <Link
-            href="/blog"
-            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
-          >
-            <Image
-              src="https://source.unsplash.com/random/800x600?writing"
-              alt="Blog"
-              fill
-              className="object-cover"
-            />
-
-            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
-
-              <h2 className="text-xl font-semibold text-white">Blog</h2>
+            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform">
+              <Image src="https://source.unsplash.com/random/800x600?writing" alt="Blog" fill className="object-cover" />
+              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+                <h2 className="text-xl font-semibold text-white">Blog</h2>
+              </div>
             </div>
-          </Link>
-
-          <Link
-            href="/skills"
-            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
-          >
-            <Image
-              src="https://source.unsplash.com/random/800x600?idea"
-              alt="Skill Sprint"
-              fill
-              className="object-cover"
-            />
-
-            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
-
-              <h2 className="text-xl font-semibold text-white">Skill Sprint</h2>
+            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform">
+              <Image src="https://source.unsplash.com/random/800x600?person" alt="About" fill className="object-cover" />
+              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+                <h2 className="text-xl font-semibold text-white">About</h2>
+              </div>
             </div>
-          </Link>
-
-          <Link
-            href="/moral"
-            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
-          >
-            <Image
-              src="https://source.unsplash.com/random/800x600?book"
-              alt="Moral Constitution"
-              fill
-              className="object-cover"
-             />
-            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
-
-              <h2 className="text-xl font-semibold text-white">Moral Code</h2>
+            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform">
+              <Image src="https://source.unsplash.com/random/800x600?resume" alt="CV" fill className="object-cover" />
+              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+                <h2 className="text-xl font-semibold text-white">CV</h2>
+              </div>
             </div>
-          </Link>
-
-          <Link
-            href="/about"
-            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
-          >
-            <Image
-              src="https://source.unsplash.com/random/800x600?person"
-              alt="About"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
-              <h2 className="text-xl font-semibold text-white">About</h2>
+            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform">
+              <Image src="https://source.unsplash.com/random/800x600?lightbulb" alt="Ideas" fill className="object-cover" />
+              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+                <h2 className="text-xl font-semibold text-white">Ideas</h2>
+              </div>
             </div>
-          </Link>
-
-          <Link
-            href="/cv"
-            className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform"
-          >
-            <Image
-              src="https://source.unsplash.com/random/800x600?resume"
-              alt="CV"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
-              <h2 className="text-xl font-semibold text-white">CV</h2>
+            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform">
+              <Image src="https://source.unsplash.com/random/800x600?book" alt="Reading" fill className="object-cover" />
+              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+                <h2 className="text-xl font-semibold text-white">Reading</h2>
+              </div>
             </div>
-          </Link>
+            <section className="col-span-2 rounded-3xl bg-gray-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Contact</h2>
+              <ul className="flex space-x-4">
+                <li>
+                  <a href="#" className="hover:opacity-80">Email</a>
+                </li>
+                <li>
+                  <a href="#" className="hover:opacity-80">LinkedIn</a>
+                </li>
+                <li>
+                  <a href="#" className="hover:opacity-80">GitHub</a>
+                </li>
+              </ul>
+            </section>
+          </div>
+        )}
 
-          <section className="col-span-2 rounded-3xl bg-pastel-green p-6 shadow-lg hover:scale-105 transition-transform">
-            <h2 className="mb-2 text-xl font-bold">Contact</h2>
-            <ul className="flex space-x-4">
-              <li>
-                <a href="#" className="hover:opacity-80">
+        {activeSection === 'Projects' && (
+          <div className="mt-8 grid w-full max-w-5xl mx-auto gap-8 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px] min-h-[80vh]">
+            <section className="relative col-span-2 row-span-2 rounded-3xl bg-blue-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Featured Project</h2>
+              <p>Summary of my favourite work.</p>
+            </section>
+            <section className="rounded-3xl bg-blue-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Project One</h2>
+            </section>
+            <section className="rounded-3xl bg-blue-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Project Two</h2>
+            </section>
+            <section className="rounded-3xl bg-blue-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Project Three</h2>
+            </section>
+            <section className="rounded-3xl bg-blue-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Project Four</h2>
+            </section>
+            <section className="rounded-3xl bg-blue-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Project Five</h2>
+            </section>
+            <section className="col-span-2 rounded-3xl bg-blue-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Contact</h2>
+              <p className="text-sm">Get in touch for more details.</p>
+            </section>
+          </div>
+        )}
 
-                  Email
-                </a>
-              </li>
-              <li>
+        {activeSection === 'Blog' && (
+          <div className="mt-8 grid w-full max-w-5xl mx-auto gap-8 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px] min-h-[80vh]">
+            <section className="relative col-span-2 row-span-2 rounded-3xl bg-orange-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Latest Post</h2>
+              <p>Coming soon.</p>
+            </section>
+            <section className="rounded-3xl bg-orange-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">All Posts</h2>
+            </section>
+            <section className="rounded-3xl bg-orange-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Writing Tips</h2>
+            </section>
+            <section className="rounded-3xl bg-orange-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Tutorials</h2>
+            </section>
+            <section className="rounded-3xl bg-orange-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Opinions</h2>
+            </section>
+            <section className="rounded-3xl bg-orange-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">News</h2>
+            </section>
+            <section className="col-span-2 rounded-3xl bg-orange-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Subscribe</h2>
+              <p className="text-sm">Stay updated with new posts.</p>
+            </section>
+          </div>
+        )}
 
-                <a href="#" className="hover:opacity-80">
+        {activeSection === 'About' && (
+          <div className="mt-8 grid w-full max-w-5xl mx-auto gap-8 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px] min-h-[80vh]">
+            <section className="relative col-span-2 row-span-2 rounded-3xl bg-purple-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Bio</h2>
+              <p>Quick introduction.</p>
+            </section>
+            <section className="rounded-3xl bg-purple-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Education</h2>
+            </section>
+            <section className="rounded-3xl bg-purple-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Interests</h2>
+            </section>
+            <section className="rounded-3xl bg-purple-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Hobbies</h2>
+            </section>
+            <section className="rounded-3xl bg-purple-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Gallery</h2>
+            </section>
+            <section className="rounded-3xl bg-purple-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Goals</h2>
+            </section>
+            <section className="col-span-2 rounded-3xl bg-purple-200 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Contact</h2>
+              <p className="text-sm">Feel free to reach out.</p>
+            </section>
+          </div>
+        )}
 
-                  LinkedIn
-                </a>
-              </li>
-              <li>
-
-                <a href="#" className="hover:opacity-80">
-
-                  GitHub
-                </a>
-              </li>
-            </ul>
-          </section>
-        </div>
+        {activeSection === 'CV' && (
+          <div className="mt-8 grid w-full max-w-5xl mx-auto gap-8 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px] min-h-[80vh]">
+            <section className="relative col-span-2 row-span-2 rounded-3xl bg-sage-300 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Resume</h2>
+              <p>Overview of my experience.</p>
+            </section>
+            <section className="rounded-3xl bg-sage-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Education</h2>
+            </section>
+            <section className="rounded-3xl bg-sage-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Skills</h2>
+            </section>
+            <section className="rounded-3xl bg-sage-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Experience</h2>
+            </section>
+            <section className="rounded-3xl bg-sage-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Projects</h2>
+            </section>
+            <section className="rounded-3xl bg-sage-100 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-lg font-semibold">Awards</h2>
+            </section>
+            <section className="col-span-2 rounded-3xl bg-sage-300 p-6 shadow-lg hover:scale-105 transition-transform">
+              <h2 className="mb-2 text-xl font-bold">Download</h2>
+              <p className="text-sm">PDF available soon.</p>
+            </section>
+          </div>
+        )}
       </main>
-
     </Layout>
-
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,19 @@ module.exports = {
         'pastel-blue': '#a7d8de',
         'pastel-yellow': '#fff3b0',
         'dark-green': '#386641',
+        'sage-100': '#E9F5DB',
+        'sage-300': '#CFE1B9',
+        'sage-500': '#97A97C',
+        'sage-700': '#718355',
+      },
+      keyframes: {
+        jiggle: {
+          '0%, 100%': { transform: 'translateX(var(--move)) scale(1)' },
+          '50%': { transform: 'translateX(var(--move)) scale(1.1)' },
+        },
+      },
+      animation: {
+        jiggle: 'jiggle 0.3s ease',
       },
     },
   },


### PR DESCRIPTION
## Summary
- tweak nav indicator to slide with bounce
- simplify home theme with neutral colors
- lighten CV theme and add darker text color
- add sage-700 to Tailwind palette

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686443b660ac83218865853f6d030d98