### PR TITLE
Centralize nav sections

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,6 +1,7 @@
 
 import React, { ReactNode } from 'react';
 import Link from 'next/link';
+import { sections } from '../lib/sections';
 
 interface LayoutProps {
   children: ReactNode;
@@ -24,7 +25,6 @@ export default function Layout({
   accentColorClass = 'text-dark-green',
   titleClass,
 }: LayoutProps) {
-  const sections = ['Home', 'Projects', 'Blog', 'About', 'CV'];
   const titleColorClass = titleClass || accentColorClass;
 
 

--- a/lib/sections.ts
+++ b/lib/sections.ts
@@ -1,0 +1,1 @@
+export const sections = ['Home', 'Projects', 'Blog', 'About', 'CV'];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
 import Layout from '../components/Layout';
-
-const sections = ['Home', 'Projects', 'Blog', 'About', 'CV'];
+import { sections } from '../lib/sections';
 
 
 const gradientClass =


### PR DESCRIPTION
## Summary
- share section list via new `lib/sections.ts`
- import `sections` in `Layout` and `index` instead of defining duplicates

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68655962a9f08321b151f13824f7adcd