### PR TITLE
Refine home page color scheme

### DIFF
--- a/components/BentoPageTransition.tsx
+++ b/components/BentoPageTransition.tsx
@@ -12,7 +12,8 @@ export function useBentoTransition() {
 }
 
 const colorMap: Record<string, string> = {
-  '/': '#E9F5DB',
+  // Use a neutral white for the landing page transition
+  '/': '#FFFFFF',
   '/projects': '#BFDBFE',
   '/blog': '#FED7AA',
   '/about': '#E9D5FF',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,8 +4,9 @@ import Image from 'next/image';
 import Layout from '../components/Layout';
 import { sections } from '../lib/sections';
 
+// Dark gray gradient for a clean monochrome look
 const gradientClass =
-  'text-transparent bg-clip-text bg-gradient-to-r from-sky-500 via-purple-500 to-pink-500';
+  'text-transparent bg-clip-text bg-gradient-to-r from-gray-700 via-gray-800 to-gray-900';
 
 export default function Home() {
   const [activeSection, setActiveSection] = useState('Home');
@@ -15,7 +16,8 @@ export default function Home() {
     string,
     { bg: string; header: string; accent: string }
   > = {
-    Home: { bg: 'bg-cream', header: 'bg-gray-100', accent: 'text-black' },
+    // Neutral palette for the landing section
+    Home: { bg: 'bg-white', header: 'bg-gray-100', accent: 'text-gray-800' },
     Projects: {
       bg: 'bg-blue-50',
       header: 'bg-blue-200',
@@ -90,7 +92,7 @@ export default function Home() {
                 fill
                 className="object-cover"
               />
-              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
                 <h2 className="text-xl font-semibold text-white">Projects</h2>
               </div>
             </div>
@@ -101,7 +103,7 @@ export default function Home() {
                 fill
                 className="object-cover"
               />
-              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
                 <h2 className="text-xl font-semibold text-white">Blog</h2>
               </div>
             </div>
@@ -112,7 +114,7 @@ export default function Home() {
                 fill
                 className="object-cover"
               />
-              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
                 <h2 className="text-xl font-semibold text-white">About</h2>
               </div>
             </div>
@@ -123,7 +125,7 @@ export default function Home() {
                 fill
                 className="object-cover"
               />
-              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
                 <h2 className="text-xl font-semibold text-white">CV</h2>
               </div>
             </div>
@@ -134,7 +136,7 @@ export default function Home() {
                 fill
                 className="object-cover"
               />
-              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
                 <h2 className="text-xl font-semibold text-white">Ideas</h2>
               </div>
             </div>
@@ -145,7 +147,7 @@ export default function Home() {
                 fill
                 className="object-cover"
               />
-              <div className="absolute inset-0 flex items-center justify-center bg-dark-green/50">
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
                 <h2 className="text-xl font-semibold text-white">Reading</h2>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- tweak gradient to dark gray for a monochrome feel
- switch landing section colors to white and gray
- change tile overlays to a gray overlay
- update page transition color for the home route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865624c86508321a47de4b86724df98