### PR TITLE
Fix unused import in Layout

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,8 +1,5 @@
 import React, { ReactNode } from 'react';
-import Link from 'next/link';
-
 import TransitionLink from './TransitionLink';
-
 
 interface LayoutProps {
   children: ReactNode;


### PR DESCRIPTION
## Summary
- remove the leftover `next/link` import from `Layout.tsx`
- verify lint succeeds with no unused variable warnings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865643d0458832185e5586fa149250b