### PR TITLE
Add listener for prefers-reduced-motion

### DIFF
--- a/components/BentoPageTransition.tsx
+++ b/components/BentoPageTransition.tsx
@@ -32,11 +32,14 @@ export default function BentoPageTransition({
   const [reducedMotion, setReducedMotion] = useState(false);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setReducedMotion(
-        window.matchMedia('(prefers-reduced-motion: reduce)').matches,
-      );
-    }
+    if (typeof window === 'undefined') return;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = () => setReducedMotion(mediaQuery.matches);
+    setReducedMotion(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
   }, []);
 
   const startTransition = (href: string) => {


### PR DESCRIPTION
## Summary
- watch the `prefers-reduced-motion` media query in `BentoPageTransition`
- clean up the listener when the component unmounts

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find name 'sections' in `Layout.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_6865643a02148321bdddecfc6eedb82d