### PR TITLE
Remove ts-ignore by adding custom CSS interface

### DIFF
--- a/components/BentoPageTransition.tsx
+++ b/components/BentoPageTransition.tsx
@@ -5,6 +5,11 @@ interface Context {
   startTransition: (href: string) => void;
 }
 
+interface OverlayStyle extends React.CSSProperties {
+  '--start-color'?: string;
+  '--end-color'?: string;
+}
+
 const BentoContext = createContext<Context>({ startTransition: () => {} });
 
 export function useBentoTransition() {
@@ -150,6 +155,12 @@ export default function BentoPageTransition({
     main?.focus();
   };
 
+  const overlayStyle: OverlayStyle = {
+    visibility: isTransitioning ? 'visible' : 'hidden',
+    '--start-color': colors.start,
+    '--end-color': colors.end,
+  };
+
   return (
     <BentoContext.Provider value={{ startTransition }}>
       {children}
@@ -157,13 +168,7 @@ export default function BentoPageTransition({
         id="bento-overlay"
         aria-hidden="true"
         className="bento-transition-overlay"
-        style={{
-          visibility: isTransitioning ? 'visible' : 'hidden',
-          //@ts-ignore
-          '--start-color': colors.start,
-          //@ts-ignore
-          '--end-color': colors.end,
-        }}
+        style={overlayStyle}
       />
     </BentoContext.Provider>
   );


### PR DESCRIPTION
## Summary
- extend `React.CSSProperties` with CSS variable support
- use the new interface instead of `//@ts-ignore`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686564384f5c8321bdd2b18bddbe696d