### PR TITLE
Fix Bento overlay CSS typing

### DIFF
--- a/components/BentoPageTransition.tsx
+++ b/components/BentoPageTransition.tsx
@@ -44,7 +44,7 @@ export default function BentoPageTransition({
         window.matchMedia('(prefers-reduced-motion: reduce)').matches,
       );
     }
-=
+
   }, []);
 
   const startTransition = (href: string) => {
@@ -172,10 +172,8 @@ export default function BentoPageTransition({
         className="bento-transition-overlay"
         style={{
           visibility: isTransitioning ? 'visible' : 'hidden',
-          //@ts-ignore
-          '--start-color': colors.start,
-          //@ts-ignore
-          '--end-color': colors.end,
+          ['--start-color' as any]: colors.start,
+          ['--end-color' as any]: colors.end,
         }}
       />
 


### PR DESCRIPTION
## Summary
- remove stray `=` from `BentoPageTransition`
- remove `@ts-ignore` and cast CSS variables explicitly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68659424276c83218f0607a3129a4db1