### PR TITLE
Update transition overlay logic and tests

### DIFF
--- a/components/BentoPageTransition.tsx
+++ b/components/BentoPageTransition.tsx
@@ -1,4 +1,3 @@
-
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { useRouter } from 'next/router';
@@ -7,8 +6,6 @@ interface Context {
   startTransition: (href: string) => void;
 }
 
-
-
 const BentoContext = createContext<Context>({ startTransition: () => {} });
 
 export function useBentoTransition() {
@@ -16,7 +13,6 @@ export function useBentoTransition() {
 }
 
 const colorMap: Record<string, string> = {
-
   '/': '#E9F5DB',
 
   '/projects': '#BFDBFE',
@@ -38,13 +34,11 @@ export default function BentoPageTransition({
   const [reducedMotion, setReducedMotion] = useState(false);
 
   useEffect(() => {
-
     if (typeof window !== 'undefined') {
       setReducedMotion(
         window.matchMedia('(prefers-reduced-motion: reduce)').matches,
       );
     }
-=
   }, []);
 
   const startTransition = (href: string) => {
@@ -96,9 +90,7 @@ export default function BentoPageTransition({
     setTimeout(done, timeout);
   };
 
-
   const animateEnter = () => {
-
     if (reducedMotion) {
       finish();
       return;
@@ -137,7 +129,6 @@ export default function BentoPageTransition({
     } else {
       finish();
     }
-
   };
 
   useEffect(() => {
@@ -155,30 +146,31 @@ export default function BentoPageTransition({
   const finish = () => {
     const overlay = document.getElementById('bento-overlay');
     overlay?.classList.remove('expand', 'fade-out');
-    setIsTransitioning(false);
     overlay?.setAttribute('style', '');
-    const main = document.querySelector('main') as HTMLElement | null;
-    main?.focus();
+    setIsTransitioning(false);
+    setTimeout(() => {
+      const main = document.querySelector('main') as HTMLElement | null;
+      main?.focus();
+    }, 0);
   };
-
 
   return (
     <BentoContext.Provider value={{ startTransition }}>
       {children}
 
-      <div
-        id="bento-overlay"
-        aria-hidden="true"
-        className="bento-transition-overlay"
-        style={{
-          visibility: isTransitioning ? 'visible' : 'hidden',
-          //@ts-ignore
-          '--start-color': colors.start,
-          //@ts-ignore
-          '--end-color': colors.end,
-        }}
-      />
-
+      {isTransitioning && (
+        <div
+          id="bento-overlay"
+          aria-hidden="true"
+          className="bento-transition-overlay"
+          style={{
+            //@ts-ignore
+            '--start-color': colors.start,
+            //@ts-ignore
+            '--end-color': colors.end,
+          }}
+        />
+      )}
     </BentoContext.Provider>
   );
 }

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -3,12 +3,7 @@ import React, { ReactNode } from 'react';
 import Link from 'next/link';
 import TransitionLink from './TransitionLink';
 
-
-import TransitionLink from './TransitionLink';
-
-
 const sections = ['Home', 'Projects', 'Blog', 'About', 'CV'];
-
 
 interface LayoutProps {
   children: ReactNode;

--- a/components/__tests__/BentoPageTransition.test.tsx
+++ b/components/__tests__/BentoPageTransition.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BentoPageTransition, {
+  useBentoTransition,
+} from '../BentoPageTransition';
+import { EventEmitter } from 'events';
+
+const events = new EventEmitter();
+const router = { pathname: '/', push: jest.fn(), events } as any;
+
+jest.mock('next/router', () => ({
+  useRouter: () => router,
+}));
+
+function TestComponent() {
+  const { startTransition } = useBentoTransition();
+  return <button onClick={() => startTransition('/projects')}>start</button>;
+}
+
+describe('BentoPageTransition', () => {
+  beforeEach(() => {
+    router.pathname = '/';
+    router.push.mockReset();
+  });
+
+  it('mounts overlay only during transitions and restores focus', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <BentoPageTransition>
+        <main tabIndex={-1}>main</main>
+        <TestComponent />
+      </BentoPageTransition>,
+    );
+
+    const main = screen.getByRole('main');
+    expect(document.getElementById('bento-overlay')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('start'));
+    expect(document.getElementById('bento-overlay')).toBeInTheDocument();
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    act(() => {
+      events.emit('routeChangeComplete');
+      jest.runOnlyPendingTimers();
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(document.getElementById('bento-overlay')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(main);
+  });
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
## Summary
- render transition overlay only when transitioning
- ensure finish unmounts overlay and restores focus
- remove duplicate import in `Layout`
- mock `matchMedia` in jest setup
- test transition overlay behavior

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865942092348321941a6632441c1b70