### PR TITLE
Implement project page showcase with Bento tiles

### DIFF
--- a/components/BentoPageTransition.tsx
+++ b/components/BentoPageTransition.tsx
@@ -188,17 +188,17 @@ export default function BentoPageTransition({
   return (
     <BentoContext.Provider value={{ startTransition }}>
       {children}
-      <div
-        id="bento-overlay"
-        aria-hidden="true"
-        className="bento-transition-overlay"
-        style={{
-          visibility: isTransitioning ? 'visible' : 'hidden',
-          //@ts-ignore
-
-          '--end-color': color,
-        }}
-      />
+      {isTransitioning && (
+        <div
+          id="bento-overlay"
+          aria-hidden="true"
+          className="bento-transition-overlay"
+          style={{
+            //@ts-ignore
+            '--end-color': color,
+          }}
+        />
+      )}
 
     </BentoContext.Provider>
   );

--- a/components/BentoTile.tsx
+++ b/components/BentoTile.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface BentoTileProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export default function BentoTile({ children, className = '' }: BentoTileProps) {
+  return (
+    <div
+      className={`rounded-3xl p-6 shadow-lg hover:scale-105 transition-transform animate-fall ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "personal-website",
       "version": "0.1.0",
       "dependencies": {
-        "next": "^14.2.30",
+        "framer-motion": "^10.16.2",
+        "next": "14.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -325,7 +326,6 @@
         "node": ">=6.0.0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -338,7 +338,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
-
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
@@ -353,13 +352,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -368,13 +365,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -386,13 +381,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
       "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -404,13 +397,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -419,13 +410,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -434,13 +423,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
       "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -452,13 +439,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -467,13 +452,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -482,13 +465,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -573,7 +554,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
       "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dev": true,
-
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -583,7 +563,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-
       }
     },
     "node_modules/@babel/runtime": {
@@ -799,6 +778,23 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -5680,6 +5676,30 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.2.tgz",
+      "integrity": "sha512-aY6L9YMvqMWtfOQptaUvvr8dp97jskXY5UYLQM0vOPxKeERrG/Z034EIQZ/52u7MeCT0HlCQy3/l0HdUZCB9Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9094,13 +9114,13 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.30.tgz",
-      "integrity": "sha512-+COdu6HQrHHFQ1S/8BBsCag61jZacmvbuL2avHvQFbWa2Ox7bE+d8FyNgxRLjXQ5wtPyQwEmk85js/AuaG2Sbg==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
+      "integrity": "sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.30",
-        "@swc/helpers": "0.5.5",
+        "@next/env": "14.1.0",
+        "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
         "graceful-fs": "^4.2.11",
@@ -9114,28 +9134,24 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.30",
-        "@next/swc-darwin-x64": "14.2.30",
-        "@next/swc-linux-arm64-gnu": "14.2.30",
-        "@next/swc-linux-arm64-musl": "14.2.30",
-        "@next/swc-linux-x64-gnu": "14.2.30",
-        "@next/swc-linux-x64-musl": "14.2.30",
-        "@next/swc-win32-arm64-msvc": "14.2.30",
-        "@next/swc-win32-ia32-msvc": "14.2.30",
-        "@next/swc-win32-x64-msvc": "14.2.30"
+        "@next/swc-darwin-arm64": "14.1.0",
+        "@next/swc-darwin-x64": "14.1.0",
+        "@next/swc-linux-arm64-gnu": "14.1.0",
+        "@next/swc-linux-arm64-musl": "14.1.0",
+        "@next/swc-linux-x64-gnu": "14.1.0",
+        "@next/swc-linux-x64-musl": "14.1.0",
+        "@next/swc-win32-arm64-msvc": "14.1.0",
+        "@next/swc-win32-ia32-msvc": "14.1.0",
+        "@next/swc-win32-x64-msvc": "14.1.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
-          "optional": true
-        },
-        "@playwright/test": {
           "optional": true
         },
         "sass": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "framer-motion": "^10.16.2",
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -1,10 +1,48 @@
-
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
+import Image from 'next/image';
+import { motion, AnimatePresence } from 'framer-motion';
 
 import Layout from '../components/Layout';
+import BentoTile from '../components/BentoTile';
+
+const kpis = [
+  { label: 'Projects', value: 20 },
+  { label: 'Papers', value: 5 },
+  { label: 'Collabs', value: 8 },
+];
+
+const slides = [
+  { title: 'Open Source Dashboard', img: '/images/pandemic_game.jpg' },
+  { title: 'Telehealth Toolkit', img: '/images/pandemic_game.jpg' },
+  { title: 'Rapid Response App', img: '/images/pandemic_game.jpg' },
+];
+
+const testimonials = [
+  { quote: 'Fantastic collaborator!', author: 'Jane D.' },
+  { quote: 'Brings great energy to teams.', author: 'A. Smith' },
+  { quote: 'Always delivers quality work.', author: 'K. Patel' },
+];
 
 export default function Projects() {
+  const [[page, direction], setPage] = useState<[number, number]>([0, 0]);
+  const [flipped, setFlipped] = useState(false);
+  const [testiIndex, setTestiIndex] = useState(0);
+
+  const paginate = (newDirection: number) => {
+    setPage([page + newDirection, newDirection]);
+  };
+
+  const index = ((page % slides.length) + slides.length) % slides.length;
+
+  useEffect(() => {
+    const id = setInterval(
+      () => setTestiIndex((i) => (i + 1) % testimonials.length),
+      8000,
+    );
+    return () => clearInterval(id);
+  }, []);
+
   return (
     <Layout>
       <Head>
@@ -12,7 +50,145 @@ export default function Projects() {
       </Head>
       <div className="min-h-screen p-8 bg-cream text-dark-green">
         <h1 className="text-3xl font-bold mb-4">Projects</h1>
-        <p>Project showcase coming soon.</p>
+        <div className="bento-grid grid gap-6 auto-rows-[250px] grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 max-w-6xl mx-auto">
+          {/* KPI left */}
+          <BentoTile className="lg:row-span-2 bg-pastel-blue flex flex-col justify-center">
+            {kpis.map((kpi) => (
+              <div key={kpi.label} className="mb-2">
+                <div className="relative h-6 bg-white rounded">
+                  <div
+                    className="absolute inset-0 bg-pastel-green opacity-40"
+                    style={{ width: `${kpi.value * 5}%` }}
+                  />
+                  <div className="relative z-10 flex justify-between px-2 text-sm font-semibold">
+                    <span>{kpi.label}</span>
+                    <span>{kpi.value}</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </BentoTile>
+          {/* Carousel */}
+          <BentoTile className="lg:col-span-2 lg:row-span-2 bg-pastel-green flex flex-col items-center justify-center">
+            <div className="relative w-full h-40 overflow-hidden">
+              <AnimatePresence initial={false} custom={direction}>
+                <motion.div
+                  key={page}
+                  custom={direction}
+                  className="absolute w-full h-full flex items-center justify-center"
+                  variants={{
+                    enter: (d: number) => ({ x: d > 0 ? 300 : -300, opacity: 0 }),
+                    center: { x: 0, opacity: 1 },
+                    exit: (d: number) => ({ x: d < 0 ? 300 : -300, opacity: 0 }),
+                  }}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={{ duration: 0.5 }}
+                  drag="x"
+                  dragConstraints={{ left: 0, right: 0 }}
+                  onDragEnd={(e, { offset }) => {
+                    if (offset.x < -50) paginate(1);
+                    else if (offset.x > 50) paginate(-1);
+                  }}
+                >
+                  <Image src={slides[index].img} alt={slides[index].title} fill className="object-cover" />
+                </motion.div>
+              </AnimatePresence>
+            </div>
+            <motion.div drag="x" className="mt-2 flex space-x-2 cursor-grab">
+              {slides.map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => setPage([i, i > index ? 1 : -1])}
+                  className={`h-2 w-2 rounded-full ${i === index ? 'bg-dark-green' : 'bg-dark-green/30'}`}
+                />
+              ))}
+            </motion.div>
+          </BentoTile>
+          {/* KPI right */}
+          <BentoTile className="lg:row-span-2 bg-pastel-blue flex flex-col justify-center">
+            {kpis.map((kpi) => (
+              <div key={kpi.label} className="mb-2">
+                <div className="relative h-6 bg-white rounded">
+                  <div
+                    className="absolute inset-0 bg-pastel-green opacity-40"
+                    style={{ width: `${kpi.value * 5}%` }}
+                  />
+                  <div className="relative z-10 flex justify-between px-2 text-sm font-semibold">
+                    <span>{kpi.label}</span>
+                    <span>{kpi.value}</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </BentoTile>
+          {/* Case Study flip card */}
+          <BentoTile
+            className="relative bg-pastel-yellow cursor-pointer"
+            onClick={() => setFlipped(!flipped)}
+          >
+            <div
+              className={`relative w-full h-full [transform-style:preserve-3d] transition-transform duration-500 ${flipped ? 'rotate-y-180' : ''}`}
+            >
+              <div className="absolute inset-0 backface-hidden flex items-center justify-center">
+                <p className="font-semibold">Case Study of the Month</p>
+              </div>
+              <div className="absolute inset-0 rotate-y-180 backface-hidden flex items-center justify-center">
+                <Image src="/images/pandemic_game.jpg" alt="Root cause" fill className="object-cover" />
+              </div>
+            </div>
+          </BentoTile>
+          {/* Skill stack matrix */}
+          <BentoTile className="bg-sage-100 animate-fall-fast">
+            <div className="grid grid-cols-4 gap-2 text-center text-sm font-medium">
+              {['React', 'TS', 'Next', 'Node', 'Python', 'Docker', 'SQL', 'Tailwind'].map((skill) => (
+                <div key={skill} className="p-2 bg-white rounded shadow">
+                  {skill}
+                </div>
+              ))}
+            </div>
+          </BentoTile>
+          {/* GitHub pulse heatmap */}
+          <BentoTile className="bg-white flex flex-col items-center justify-center">
+            <div className="grid grid-cols-7 gap-1">
+              {Array.from({ length: 49 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="w-3 h-3"
+                  style={{ backgroundColor: i % 5 === 0 ? '#97A97C' : '#CFE1B9' }}
+                />
+              ))}
+            </div>
+            <svg viewBox="0 0 100 20" className="mt-2 w-full h-4">
+              <polyline
+                fill="none"
+                stroke="#386641"
+                strokeWidth="2"
+                points="0,15 20,10 40,12 60,8 80,13 100,5"
+              />
+            </svg>
+          </BentoTile>
+          {/* LinkedIn testimonials */}
+          <BentoTile className="bg-pastel-green flex flex-col items-center justify-center">
+            <div className="text-center">
+              <p className="italic mb-2 transition-opacity duration-300">
+                {testimonials[testiIndex].quote}
+              </p>
+              <p className="text-sm font-semibold">{testimonials[testiIndex].author}</p>
+            </div>
+          </BentoTile>
+          {/* Contact CTA */}
+          <BentoTile className="lg:col-span-4 bg-dark-green text-white text-center">
+            <h2 className="text-xl font-bold mb-2">Let&apos;s work together</h2>
+            <p>
+              Email:{' '}
+              <a href="mailto:email@example.com" className="underline">
+                email@example.com
+              </a>
+            </p>
+          </BentoTile>
+        </div>
       </div>
     </Layout>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,10 @@ module.exports = {
           '0%': { transform: 'translateY(-40px)', opacity: '0' },
           '100%': { transform: 'translateY(0)', opacity: '1' },
         },
+        flip: {
+          '0%': { transform: 'rotateY(0deg)' },
+          '100%': { transform: 'rotateY(180deg)' },
+        },
         ripple: {
           '0%': { transform: 'scale(0)', opacity: '0.6' },
           '100%': { transform: 'scale(1)', opacity: '0' },
@@ -39,6 +43,8 @@ module.exports = {
         jiggle: 'jiggle 0.3s ease',
         fall: 'fall 0.4s ease-out both',
         ripple: 'ripple 0.6s ease-out forwards',
+        'fall-fast': 'fall 0.28s ease-out both',
+        flip: 'flip 0.6s ease-in-out forwards',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add BentoTile component and animations
- build project showcase layout using BentoTile with carousel and KPI tiles
- include flip card, skill matrix, GitHub heatmap, testimonials and contact CTA
- update BentoPageTransition overlay logic
- install framer-motion

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697ea740088321bfac9862a95b1e14