### PR TITLE
Revamp home bento grid

### DIFF
--- a/components/__tests__/BentoPageTransition.test.tsx
+++ b/components/__tests__/BentoPageTransition.test.tsx
@@ -34,7 +34,9 @@ describe('BentoPageTransition', () => {
     );
 
     const main = screen.getByRole('main');
-    expect(document.getElementById('bento-overlay')).not.toBeInTheDocument();
+    const overlay = document.getElementById('bento-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveStyle('visibility: hidden');
 
     await user.click(screen.getByText('start'));
     expect(document.getElementById('bento-overlay')).toBeInTheDocument();
@@ -48,7 +50,7 @@ describe('BentoPageTransition', () => {
       jest.runOnlyPendingTimers();
     });
 
-    expect(document.getElementById('bento-overlay')).not.toBeInTheDocument();
+    expect(document.getElementById('bento-overlay')).toHaveStyle('visibility: hidden');
     expect(document.activeElement).toBe(main);
   });
 });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,6 +35,43 @@ export default function Home() {
     CV: { bg: 'bg-sage-100', header: 'bg-sage-300', accent: 'text-sage-700' },
   };
 
+  const elevatorText = [
+    'Medical student and researcher.',
+    'Tech enthusiast and builder.',
+    'Advocating for better health.',
+  ];
+  const [phraseIndex, setPhraseIndex] = useState(0);
+
+  const [builtCount, setBuiltCount] = useState(0);
+  const [printCount, setPrintCount] = useState(0);
+  const [collabCount, setCollabCount] = useState(0);
+  const [flipped, setFlipped] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setPhraseIndex((i) => (i + 1) % elevatorText.length),
+      2000,
+    );
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (activeSection !== 'Home') return;
+    setBuiltCount(0);
+    setPrintCount(0);
+    setCollabCount(0);
+    const targets = [20, 5, 8];
+    const setters = [setBuiltCount, setPrintCount, setCollabCount];
+    targets.forEach((target, index) => {
+      let current = 0;
+      const id = setInterval(() => {
+        current += 1;
+        setters[index](current);
+        if (current >= target) clearInterval(id);
+      }, 60);
+    });
+  }, [activeSection]);
+
   const handleSectionChange = (section: string) => {
     if (section === activeSection) return;
     setActiveSection(section);
@@ -77,154 +114,64 @@ export default function Home() {
 
       <main className="flex items-center justify-center pt-12">
         {activeSection === 'Home' && (
-          <div className="bento-grid mt-8 grid w-full max-w-5xl mx-auto gap-8 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px] min-h-[80vh]">
-            <section className="relative col-span-2 row-span-2 rounded-3xl bg-gray-200 p-6 shadow-lg hover:scale-105 transition-transform animate-fall">
-              <h2 className="mb-2 text-xl font-bold flex items-center gap-2">
-                <span> <Image
-  src="/images/memoji.png"
-  alt="demo me"
-  width={200}
-  height={200}
-/> ﻿</span>About
-              </h2>
-              <p>Hi, I’m Rohan. I’m a medical student and public health researcher who cares deeply about making health and development more fair, 
-                more efficient, and more future-proof. Whether I’m working on the wards, writing policy, or uilding somethingfrom scratch, 
-                I’m drawn to work that’s grounded, collaborative, and ambitious. I’m especially interested in how emerging technology can improve public health, 
-                strengthen biosecurity, and help global systems serve people better. I’m always looking to connect with others working toward the same goals..</p>
-             
+          <div className="bento-grid mt-8 grid w-full max-w-5xl mx-auto gap-6 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px]">
+            <section className="col-span-2 row-span-2 rounded-3xl bg-gray-200 p-6 shadow-lg flex flex-col justify-center animate-fall">
+              <h2 className="mb-4 text-xl font-bold">{elevatorText[phraseIndex]}</h2>
+              <p className="text-sm">Welcome to my corner of the web.</p>
             </section>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?laptop"
-                alt="Projects"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Projects</h2>
-              </div>
+
+            <div className="relative rounded-3xl overflow-hidden shadow-lg hover:rotate-2 transition-transform animate-fall">
+              <Image src="/images/memoji.png" alt="selfie" fill className="object-cover" />
             </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?writing"
-                alt="Blog"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Blog</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?person"
-                alt="About"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">About</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?resume"
-                alt="CV"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">CV</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?lightbulb"
-                alt="Ideas"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Ideas</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?book"
-                alt="Reading"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Reading</h2>
+
+            <div className="relative rounded-3xl overflow-hidden shadow-lg animate-fall">
+              <Image src="https://source.unsplash.com/800x600?map" alt="map" fill className="object-cover" />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Image src="/images/memoji.png" alt="pin" width={60} height={60} className="animate-ping" />
               </div>
             </div>
 
-            <section className="col-span-2 rounded-3xl bg-gray-200 p-6 shadow-lg hover:scale-105 transition-transform animate-fall flex flex-col items-center justify-center text-center">
+            <section className="col-span-2 row-span-2 rounded-3xl bg-gray-200 p-6 shadow-lg flex flex-col items-center justify-center text-center animate-fall">
               <h2 className="mb-4 text-xl font-bold">Impact Snapshot</h2>
               <div className="grid grid-cols-3 gap-4 w-full">
-                <div>
-
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                    className="mx-auto h-8 w-8"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z"
-                    />
-                  </svg>
-
+                <div className="flex flex-col items-center">
+                  <div className="text-3xl font-bold">{builtCount}</div>
                   <div className="text-sm font-semibold">Built</div>
-                  <div className="text-3xl font-bold">20</div>
                 </div>
-                <div>
-
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                    className="mx-auto h-8 w-8"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z"
-                    />
-                  </svg>
-
+                <div className="flex flex-col items-center">
+                  <div className="text-3xl font-bold">{printCount}</div>
                   <div className="text-sm font-semibold">In Print</div>
-                  <div className="text-3xl font-bold">5</div>
                 </div>
-                <div>
-
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                    className="mx-auto h-8 w-8"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z"
-                    />
-                  </svg>
-
+                <div className="flex flex-col items-center">
+                  <div className="text-3xl font-bold">{collabCount}</div>
                   <div className="text-sm font-semibold">Collabs</div>
-                  <div className="text-3xl font-bold">8</div>
                 </div>
               </div>
             </section>
+
+            <div className="rounded-3xl bg-gray-100 p-6 shadow-lg grid grid-cols-3 gap-2 animate-fall">
+              {['JS', 'TS', 'React', 'Node', 'Next', 'Tailwind'].map((s, i) => (
+                <div key={s} style={{ animationDelay: `${i * 100}ms` }} className="flex items-center justify-center font-mono text-sm opacity-0 animate-fall">
+                  {s}
+                </div>
+              ))}
+            </div>
+
+            <div className="rounded-3xl bg-gray-100 p-6 shadow-lg text-center cursor-pointer animate-fall" onClick={() => setFlipped(!flipped)}>
+              {flipped ? (
+                <div className="animate-bounce">🎉 Biosecurity rocks!</div>
+              ) : (
+                <div>Biosecurity Byte</div>
+              )}
+            </div>
+
+            <div className="rounded-3xl bg-gray-200 p-6 shadow-lg flex items-center justify-center text-center animate-heartbeat">
+              Contact Me
+            </div>
+            <div className="rounded-3xl bg-gray-200 p-6 shadow-lg flex items-center justify-center text-center relative overflow-hidden animate-fall">
+              <span className="absolute left-0 top-0 h-full bg-gray-300 animate-progress" />
+              <span className="relative">Download CV</span>
+            </div>
           </div>
         )}
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,11 +34,21 @@ module.exports = {
           '0%': { transform: 'scale(0)', opacity: '0.6' },
           '100%': { transform: 'scale(1)', opacity: '0' },
         },
+        heartbeat: {
+          '0%, 100%': { transform: 'scale(1)' },
+          '50%': { transform: 'scale(1.05)' },
+        },
+        progress: {
+          '0%': { width: '0%' },
+          '100%': { width: '100%' },
+        },
       },
       animation: {
         jiggle: 'jiggle 0.3s ease',
         fall: 'fall 0.4s ease-out both',
         ripple: 'ripple 0.6s ease-out forwards',
+        heartbeat: 'heartbeat 1s ease-in-out infinite',
+        progress: 'progress 2s linear infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- redesign the home page bento grid with new interactive tiles
- add animations for heartbeat and progress
- update BentoPageTransition tests for persistent overlay

## Testing
- `npm run build`
- `npm run dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68697ea5e61883219006160938e6e303