### PR TITLE
Add BentoTile component

### DIFF
--- a/components/BentoTile.tsx
+++ b/components/BentoTile.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import Image from 'next/image';
+
+export interface BentoTileProps {
+  title: string;
+  /** Optional image source for the background */
+  imgSrc?: string;
+  /** Additional css classes for the tile */
+  className?: string;
+  /** Tailwind animation/hover classes */
+  animationClass?: string;
+  /** Children rendered inside the tile */
+  children?: React.ReactNode;
+}
+
+/**
+ * Basic tile used throughout the bento layout. It renders an optional
+ * background image and overlay title text. Animations can be customised via
+ * the `animationClass` prop.
+ */
+export default function BentoTile({
+  title,
+  imgSrc,
+  className = '',
+  animationClass = 'hover:scale-105 transition-transform animate-fall',
+  children,
+}: BentoTileProps) {
+  return (
+    <div
+      className={`relative overflow-hidden rounded-3xl shadow-lg ${animationClass} ${className}`}
+    >
+      {imgSrc && (
+        <Image src={imgSrc} alt={title} fill className="object-cover" />
+      )}
+      <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
+        <h2 className="text-xl font-semibold text-white">{title}</h2>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function PolaroidTile(props: BentoTileProps) {
+  return (
+    <BentoTile
+      {...props}
+      className={`bg-white p-4 ${props.className ?? ''}`.trim()}
+      animationClass={
+        props.animationClass || 'hover:rotate-2 hover:scale-105 transition-transform animate-fall'
+      }
+    />
+  );
+}
+
+export function MapTile(props: BentoTileProps) {
+  return (
+    <BentoTile
+      {...props}
+      className={`bg-blue-100 ${props.className ?? ''}`.trim()}
+      animationClass={props.animationClass}
+    />
+  );
+}
+
+export function CarouselTile(props: BentoTileProps) {
+  return (
+    <BentoTile
+      {...props}
+      className={`overflow-hidden ${props.className ?? ''}`.trim()}
+      animationClass={props.animationClass}
+    />
+  );
+}

--- a/components/__tests__/BentoPageTransition.test.tsx
+++ b/components/__tests__/BentoPageTransition.test.tsx
@@ -34,10 +34,12 @@ describe('BentoPageTransition', () => {
     );
 
     const main = screen.getByRole('main');
-    expect(document.getElementById('bento-overlay')).not.toBeInTheDocument();
+    const overlay = document.getElementById('bento-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay?.style.visibility).toBe('hidden');
 
     await user.click(screen.getByText('start'));
-    expect(document.getElementById('bento-overlay')).toBeInTheDocument();
+    expect(overlay?.style.visibility).toBe('visible');
 
     act(() => {
       jest.runOnlyPendingTimers();
@@ -48,7 +50,7 @@ describe('BentoPageTransition', () => {
       jest.runOnlyPendingTimers();
     });
 
-    expect(document.getElementById('bento-overlay')).not.toBeInTheDocument();
+    expect(overlay?.style.visibility).toBe('hidden');
     expect(document.activeElement).toBe(main);
   });
 });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
 import Layout from '../components/Layout';
+import BentoTile from '../components/BentoTile';
 
 
 const gradientClass =
@@ -93,72 +94,30 @@ export default function Home() {
                 strengthen biosecurity, and help global systems serve people better. I’m always looking to connect with others working toward the same goals..</p>
              
             </section>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?laptop"
-                alt="Projects"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Projects</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?writing"
-                alt="Blog"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Blog</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?person"
-                alt="About"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">About</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?resume"
-                alt="CV"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">CV</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?lightbulb"
-                alt="Ideas"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Ideas</h2>
-              </div>
-            </div>
-            <div className="relative overflow-hidden rounded-3xl shadow-lg hover:scale-105 transition-transform animate-fall">
-              <Image
-                src="https://source.unsplash.com/random/800x600?book"
-                alt="Reading"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-800/50">
-                <h2 className="text-xl font-semibold text-white">Reading</h2>
-              </div>
-            </div>
+            <BentoTile
+              title="Projects"
+              imgSrc="https://source.unsplash.com/random/800x600?laptop"
+            />
+            <BentoTile
+              title="Blog"
+              imgSrc="https://source.unsplash.com/random/800x600?writing"
+            />
+            <BentoTile
+              title="About"
+              imgSrc="https://source.unsplash.com/random/800x600?person"
+            />
+            <BentoTile
+              title="CV"
+              imgSrc="https://source.unsplash.com/random/800x600?resume"
+            />
+            <BentoTile
+              title="Ideas"
+              imgSrc="https://source.unsplash.com/random/800x600?lightbulb"
+            />
+            <BentoTile
+              title="Reading"
+              imgSrc="https://source.unsplash.com/random/800x600?book"
+            />
 
             <section className="col-span-2 rounded-3xl bg-gray-200 p-6 shadow-lg hover:scale-105 transition-transform animate-fall flex flex-col items-center justify-center text-center">
               <h2 className="mb-4 text-xl font-bold">Impact Snapshot</h2>


### PR DESCRIPTION
## Summary
- introduce `BentoTile` component with default overlay and animation
- provide `PolaroidTile`, `MapTile`, and `CarouselTile` helpers
- replace repeated markup on the home page with `BentoTile`
- update BentoPageTransition test for the persistent overlay

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697ea35ccc832192d497b6cc0386ef