### PR TITLE
Add interactive component tests

### DIFF
--- a/components/__tests__/BentoPageTransition.test.tsx
+++ b/components/__tests__/BentoPageTransition.test.tsx
@@ -35,12 +35,12 @@ describe('BentoPageTransition', () => {
 
     const main = screen.getByRole('main');
 
-    let overlay = document.getElementById('bento-overlay');
-    expect(overlay).toBeNull();
+    const overlay = document.getElementById('bento-overlay') as HTMLElement;
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveStyle('visibility: hidden');
 
     await user.click(screen.getByText('start'));
-    overlay = document.getElementById('bento-overlay');
-    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveStyle('visibility: visible');
 
     act(() => {
       jest.runOnlyPendingTimers();
@@ -50,6 +50,8 @@ describe('BentoPageTransition', () => {
       jest.runOnlyPendingTimers();
       jest.runOnlyPendingTimers();
     });
+
+    expect(overlay).toHaveStyle('visibility: hidden');
 
     expect(document.activeElement).toBe(main);
   });

--- a/components/__tests__/BentoTile.test.tsx
+++ b/components/__tests__/BentoTile.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import BentoTile from '../BentoTile';
+
+test('BentoTile renders children and animation classes', () => {
+  render(
+    <BentoTile className="extra" animationClass="animate-test">
+      <span>content</span>
+    </BentoTile>
+  );
+  const tile = screen.getByText('content').parentElement as HTMLElement;
+  expect(tile).toHaveClass('animate-test');
+  expect(tile).toHaveClass('extra');
+});

--- a/components/__tests__/Carousel.test.tsx
+++ b/components/__tests__/Carousel.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Projects from '../../pages/projects';
+
+test('carousel dot click changes slide', async () => {
+  const user = userEvent.setup();
+  const { container } = render(<Projects />);
+
+  expect(screen.getByAltText('Open Source Dashboard')).toBeInTheDocument();
+
+  const dotsContainer = container.querySelector('.cursor-grab') as HTMLElement;
+  const dots = within(dotsContainer).getAllByRole('button');
+  await user.click(dots[1]);
+
+  expect(screen.getByAltText('Telehealth Toolkit')).toBeInTheDocument();
+});

--- a/components/__tests__/FlipCard.test.tsx
+++ b/components/__tests__/FlipCard.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Home from '../../pages/index';
+
+test('flip card reveals celebration message', async () => {
+  const user = userEvent.setup();
+  render(<Home />);
+
+  const tile = screen.getByText('Biosecurity Byte');
+  await user.click(tile);
+
+  expect(screen.getByText('🎉 Biosecurity rocks!')).toBeInTheDocument();
+});

--- a/components/__tests__/Konami.test.tsx
+++ b/components/__tests__/Konami.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import About from '../../pages/about';
+
+beforeEach(() => {
+  (window as any).AudioContext = jest.fn().mockImplementation(() => ({
+    createOscillator: () => ({
+      type: '',
+      frequency: { value: 0 },
+      connect: jest.fn(),
+      start: jest.fn(),
+      stop: jest.fn(),
+    }),
+    destination: null,
+    currentTime: 0,
+  }));
+});
+
+test('konami code reveals pixel art', async () => {
+  const user = userEvent.setup();
+  render(<About />);
+
+  expect(screen.queryByText('🎉')).toBeNull();
+
+  const keys = [
+    'ArrowUp',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowLeft',
+    'ArrowRight',
+    'b',
+    'a',
+  ];
+
+  for (const key of keys) {
+    if (key.startsWith('Arrow')) {
+      await user.keyboard(`{${key}}`);
+    } else {
+      await user.keyboard(key);
+    }
+  }
+
+  expect(await screen.findByText('🎉')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add tests for BentoTile basic rendering
- test carousel dot interaction in projects page
- verify home flip card toggles celebration message
- test konami code easter egg on about page
- adjust BentoPageTransition test to check overlay visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869908449b483219bbdc42c66893037