### PR TITLE
Improve home page visual style

### DIFF
--- a/components/ElevatorPitchTile.tsx
+++ b/components/ElevatorPitchTile.tsx
@@ -18,10 +18,10 @@ export default function ElevatorPitchTile() {
       animate={inView ? { opacity: 1, y: 0 } : {}}
       transition={{ duration: 0.2 }}
       aria-label="Personal introduction: Hi I'm Rohan, Med student turned tech-forward biosecurity thinker."
-      className="col-span-full sm:col-span-2 md:col-span-2 row-span-2 rounded-2xl bg-white bg-cover shadow-lg hover:shadow-xl p-6"
+      className="rounded-2xl bg-white shadow-lg hover:shadow-xl p-6 h-full"
     >
       <h1 className="font-poppins font-bold text-2xl leading-10 text-black">
-        Hi, I'm Rohan.
+        Hi, I&apos;m Rohan.
       </h1>
       <p className="font-poppins font-medium text-xl leading-8 text-black">
         <span>{text}</span>

--- a/components/PolaroidSelfieTile.tsx
+++ b/components/PolaroidSelfieTile.tsx
@@ -31,8 +31,8 @@ export default function PolaroidSelfieTile() {
   return (
     <motion.div
       role="img"
-      aria-label="Photograph of Rohan"
-      className="relative aspect-[3/4] w-full sm:col-span-1 sm:row-span-1 md:col-span-1 xl:col-span-1"
+      aria-label="Photograph of Uzma"
+      className="relative aspect-[3/4] w-full h-full"
       style={{
         perspective: 800,
         rotateX: springX,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -10,6 +10,14 @@ Object.defineProperty(window, 'matchMedia', {
     removeListener: jest.fn(),
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
+  dispatchEvent: jest.fn(),
   })),
 });
+
+class IntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+window.IntersectionObserver = IntersectionObserver;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,7 +22,7 @@ export default function Home() {
     { bg: string; header: string; accent: string }
   > = {
     // Neutral palette for the landing section
-    Home: { bg: 'bg-white', header: 'bg-gray-100', accent: 'text-gray-800' },
+    Home: { bg: 'bg-gray-50', header: 'bg-white', accent: 'text-sky-600' },
     Projects: {
       bg: 'bg-blue-50',
       header: 'bg-blue-200',
@@ -106,16 +106,33 @@ export default function Home() {
 
       <main className="flex items-center justify-center pt-12">
         {activeSection === 'Home' && (
-          <div className="bento-grid mt-8 grid w-full max-w-5xl mx-auto gap-6 p-6 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px]">
+          <div className="bento-grid mt-8 grid w-full max-w-5xl mx-auto gap-6 p-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 auto-rows-[220px]">
 
             <ElevatorPitchTile />
 
 
 
+
             <PolaroidSelfieTile />
 
+            <BentoTile
+              className="relative bg-pastel-yellow cursor-pointer"
+              onClick={() => setFlipped(!flipped)}
+            >
+              <div
+                className={`relative w-full h-full [transform-style:preserve-3d] transition-transform duration-500 ${flipped ? 'rotate-y-180' : ''}`}
+              >
+                <div className="absolute inset-0 backface-hidden flex items-center justify-center">
+                  Biosecurity Byte
+                </div>
+                <div className="absolute inset-0 rotate-y-180 backface-hidden flex items-center justify-center">
+                  🎉 Biosecurity rocks!
+                </div>
+              </div>
+            </BentoTile>
 
-            <section className="col-span-2 row-span-1 rounded-3xl bg-gray-200 p-6 shadow-lg flex flex-col items-center justify-center text-center animate-fall">
+
+            <section className="rounded-3xl bg-white p-6 shadow-lg flex flex-col items-center justify-center text-center animate-fall">
               <h2 className="mb-4 text-xl font-bold">Impact Snapshot</h2>
               <div className="grid grid-cols-3 gap-4 w-full">
                 <div className="flex flex-col items-center">
@@ -135,7 +152,7 @@ export default function Home() {
 
           
 
-            <div className="rounded-3xl bg-gray-200 p-6 shadow-lg flex items-center justify-center text-center animate-heartbeat">
+            <div className="rounded-3xl bg-white p-6 shadow-lg flex items-center justify-center text-center border border-gray-200 text-sky-600 animate-heartbeat">
               Contact Me
             </div>
             <DownloadCvTile />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,7 +8,7 @@
 
 @layer base {
   body {
-    @apply font-sans;
+    @apply font-poppins bg-gray-50 text-gray-800;
   }
   h1,
   h2,
@@ -16,7 +16,7 @@
   h4,
   h5,
   h6 {
-    @apply font-mono;
+    @apply font-poppins font-bold text-gray-900;
   }
 }
 


### PR DESCRIPTION
## Summary
- restyle the site with Poppins font and soft neutral colours
- tweak home page theming and bento grid layout
- add flip card tile that reveals a celebration message
- adjust Polaroid selfie tile accessibility
- stub IntersectionObserver for tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68699cb5e8fc83218d081c664e4f9475