### PR TITLE
Add hover scaling using framer motion

### DIFF
--- a/components/BentoTile.tsx
+++ b/components/BentoTile.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import { motion } from 'framer-motion';
 
 export interface BentoTileProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string;
@@ -25,9 +26,8 @@ const BentoTile = React.forwardRef<HTMLDivElement, BentoTileProps>(
       imgSrc,
       className = '',
 
-     
-      animationClass =
-        'hover:scale-105 transition-transform motion-safe:animate-fall',
+
+      animationClass = 'motion-safe:animate-fall',
 
       children,
       ...rest
@@ -35,9 +35,11 @@ const BentoTile = React.forwardRef<HTMLDivElement, BentoTileProps>(
     ref,
   ) => {
     return (
-      <div
+      <motion.div
         ref={ref}
-        className={`relative overflow-hidden rounded-3xl shadow-elev ${animationClass} ${className}`}
+        whileHover={{ scale: 1.05 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+        className={`relative overflow-hidden rounded-3xl shadow-elev transition-transform ${animationClass} ${className}`}
         {...rest}
       >
         {imgSrc && (
@@ -49,7 +51,7 @@ const BentoTile = React.forwardRef<HTMLDivElement, BentoTileProps>(
           </div>
         )}
         {children}
-      </div>
+      </motion.div>
     );
   },
 );
@@ -65,9 +67,7 @@ export function PolaroidTile(props: BentoTileProps) {
       className={`bg-white p-4 ${props.className ?? ''}`.trim()}
       animationClass={
         props.animationClass ||
-
-        'hover:rotate-2 hover:scale-105 transition-transform motion-safe:animate-fall'
-
+        'hover:rotate-2 motion-safe:animate-fall'
       }
     />
   );


### PR DESCRIPTION
## Summary
- switch `BentoTile` to a `motion.div`
- add spring-based hover scaling
- adjust `PolaroidTile` default classes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a5e09493c8321ae5875ed7e86139c