### PR TITLE
Increase Polaroid border for more realistic look

### DIFF
--- a/components/PolaroidSelfieTile.tsx
+++ b/components/PolaroidSelfieTile.tsx
@@ -56,7 +56,7 @@ export default function PolaroidSelfieTile({
           src="/images/IMG_8264.jpeg"
           alt="Rohan"
           fill
-          className="rounded-lg object-cover border-[10px] border-white pb-4"
+          className="rounded-lg object-cover border-[12px] border-white pb-8"
         />
         <motion.figcaption
           variants={captionVariants}


### PR DESCRIPTION
## Summary
- enlarge the white border around the Polaroid selfie
- extend the bottom padding for a thicker base

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6651b2e48321843df2235a17e9a7