### PR TITLE
Update elevator pitch layout with foundation image

### DIFF
--- a/components/ElevatorPitchTile.tsx
+++ b/components/ElevatorPitchTile.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import Image from 'next/image';
 import { motion, useInView, useReducedMotion } from 'framer-motion';
 import useRotatingText from './useRotatingText';
 
@@ -26,22 +27,21 @@ export default function ElevatorPitchTile({
       initial={{ opacity: 0, y: reduce ? 0 : 20 }}
       animate={inView ? { opacity: 1, y: 0 } : {}}
       transition={{ duration: 0.2 }}
-
       aria-label="Personal introduction: Hi I'm Rohan, Med student turned tech-forward biosecurity thinker."
-      className={`rounded-2xl bg-white shadow-elev hover:shadow-xl p-6 h-full ${className}`}
-
+      className={`relative flex flex-col justify-end rounded-2xl bg-white shadow-elev hover:shadow-xl p-6 h-full overflow-hidden ${className}`}
     >
+      <Image
+        src="/images/foundation.png"
+        alt="Foundation"
+        width={80}
+        height={80}
+        className="absolute top-0 left-0 w-16 h-16 object-contain"
+      />
       <h1 className="font-poppins font-bold text-2xl leading-10 text-black">
-        
-      
-
-        
         Hi, I&apos;m Rohan.
       </h1>
       <p className="font-poppins font-medium text-xl leading-8 text-black">
-
         {text}
-
       </p>
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- show a foundation image in the top-left of the elevator pitch tile
- position the pitch text at the bottom of the tile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a69cef1b88321afa7624702acefe3