### PR TITLE
Expand lobby grid with new highlights tile

### DIFF
--- a/components/__tests__/BentoTile.test.tsx
+++ b/components/__tests__/BentoTile.test.tsx
@@ -7,7 +7,8 @@ test('BentoTile renders children and animation classes', () => {
       <span>content</span>
     </BentoTile>
   );
-  const tile = screen.getByText('content').parentElement as HTMLElement;
-  expect(tile).toHaveClass('animate-test');
-  expect(tile).toHaveClass('extra');
+  const inner = screen.getByText('content').parentElement as HTMLElement;
+  const outer = inner.parentElement as HTMLElement;
+  expect(inner).toHaveClass('animate-test');
+  expect(outer).toHaveClass('extra');
 });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -109,7 +109,10 @@ export default function Home() {
 
             <PolaroidSelfieTile className="col-span-12 lg:col-span-4 row-span-2" />
 
-            <BentoTile className="lg:row-span-2 lg:col-span-2 bg-white flex flex-col justify-center" />
+            <BentoTile className="col-span-12 lg:col-span-4 lg:row-span-3 bg-white flex flex-col items-center justify-center">
+              <h2 className="text-xl font-semibold">Highlights</h2>
+              <p className="text-sm text-center">A quick overview of key skills and achievements.</p>
+            </BentoTile>
 
            
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,10 +99,10 @@
 .lobby-grid {
   display: grid;
   gap: 24px;
-  grid-template-columns: repeat(12, minmax(50px, 50px));
+  grid-template-columns: repeat(16, minmax(0, 1fr));
   grid-auto-rows: 180px;
   margin: 0 auto;
-  max-width: 1248px;
+  max-width: 1600px;
   padding: 0 96px;
 }
 


### PR DESCRIPTION
## Summary
- adjust lobby-grid to allow 16 columns and wider width
- replace placeholder tile on home page with a taller Highlights tile
- update BentoTile test to reflect DOM structure

## Testing
- `npm test`
- `npm run dev` *(verified server starts)*

------
https://chatgpt.com/codex/tasks/task_e_686aece03ee88321a525d7fc9a79cef7